### PR TITLE
Audit: Lock Config

### DIFF
--- a/contracts/Bazaar.sol
+++ b/contracts/Bazaar.sol
@@ -151,7 +151,8 @@ contract Bazaar is Initializable, OwnableUpgradeable, ERC1155Upgradeable, IERC29
 
         require(royalty <= feeDenominator, "royalty will exceed sale price");
         require(limit == 0 || limit >= listing.supply, "limit lower than supply");
-        
+        require(listing.supply == 0 || listing.isUnlocked(config), "config is locked");
+
         listing.config = config;
         listing.limit = limit;
         listing.allow = allow;

--- a/contracts/Listings.sol
+++ b/contracts/Listings.sol
@@ -12,6 +12,8 @@ library Listings {
     uint256 constant CONFIG_SOULBOUND = 1 << 2;
     // config flag enforces one item per address
     uint256 constant CONFIG_UNIQUE = 1 << 3;
+    // config mask for flags that cannot be changed after minting
+    uint256 constant CONFIG_LOCK_MASK = CONFIG_SOULBOUND | CONFIG_UNIQUE;
     
     struct Listing {
         // vendor address
@@ -54,5 +56,10 @@ library Listings {
     function isAllowed(Listing storage listing, address sender, bytes32[] calldata proof) internal view returns (bool) {
         bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(sender))));
         return MerkleProof.verifyCalldata(proof, bytes32(listing.allow), leaf);
+    }
+
+    /// @dev Returns true if the configuration changes do not touch any locked values.
+    function isUnlocked(Listing storage listing, uint256 config) internal view returns (bool) {
+        return (config & CONFIG_LOCK_MASK) == (listing.config & CONFIG_LOCK_MASK);
     }
 }


### PR DESCRIPTION
Closes https://github.com/berndartmueller/2023-02-bazaar-buidlers/issues/6

- Lock `CONFIG_SOULBOUND` and `CONFIG_UNIQUE` when supply is non-zero

I think locking both soulbound and unique is the correct choice to protect buyers. I created a mask to check all the locked config flags and added it to a helper function in `Listings.sol`.