### PR TITLE
Audit: QA Solidity Version

### DIFF
--- a/contracts/Bazaar.sol
+++ b/contracts/Bazaar.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/interfaces/IERC2981Upgradeable.sol";

--- a/contracts/Escrow.sol
+++ b/contracts/Escrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/Listings.sol
+++ b/contracts/Listings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.9;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 


### PR DESCRIPTION
Closes https://github.com/berndartmueller/2023-02-bazaar-buidlers/issues/12

- Lock solidity version to 0.8.17